### PR TITLE
Add build-docker-sha.yaml

### DIFF
--- a/.github/workflows/build-docker-sha.yaml
+++ b/.github/workflows/build-docker-sha.yaml
@@ -32,6 +32,7 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/waiting-dog
           tags: |
             type=sha
+            value=latest
       - name: Build container image
         uses: docker/build-push-action@v5
         with:
@@ -50,6 +51,7 @@ jobs:
           images: whywaita.sakuracr.jp/waiting-dog
           tags: |
             type=sha
+            value=latest
       - name: Build container image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/build-docker-sha.yaml
+++ b/.github/workflows/build-docker-sha.yaml
@@ -1,0 +1,57 @@
+name: Build Docker image (sha)
+on:
+  push:
+    branches:
+      - "**"
+  workflow_dispatch:
+
+jobs:
+  docker-build-sha:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/waiting-dog
+          tags: |
+            type=sha
+      - name: Build container image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Login to sakuracr registry
+        uses: docker/login-action@v3
+        with:
+          registry: whywaita.sakuracr.jp
+          username: github-actions
+          password: ${{ secrets.SAKURACR_PASSWORD }}
+      - uses: docker/metadata-action@v5
+        id: meta-sakuracr
+        with:
+          images: whywaita.sakuracr.jp/waiting-dog
+          tags: |
+            type=sha
+      - name: Build container image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ steps.meta-sakuracr.outputs.tags }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to build and push Docker images based on the commit SHA. The changes include setting up the workflow, caching Docker layers, logging into container registries, and building and pushing the Docker images.

New GitHub Actions workflow:

* [`.github/workflows/build-docker-sha.yaml`](diffhunk://#diff-28780a0d5b68e8dbf19c010951964ed7d0a8dac1b10780a6f3acab9deaf14b59R1-R57): Added a new workflow to build Docker images on every push to any branch and on manual dispatch. The workflow includes steps to checkout the repository, set up QEMU and Buildx, cache Docker layers, log in to GitHub Container Registry and Sakuracr registry, and build and push the Docker images.